### PR TITLE
[#601] Enforce skipping rebuild of builds

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -55,7 +55,9 @@ public class BuildManager {
     }
 
     public ManagedBuildReference deploy(ManagedBuild managedBuild) {
-        if (BuildManagerConfig.forceRebuild()) {
+        if (BuildManagerConfig.skipRebuild()) {
+            log.info("Skip rebuilding is enabled... Skipping rebuild of '{}'.", managedBuild.getId());
+        } else if (BuildManagerConfig.forceRebuild()) {
             log.info("Force rebuilding is enabled... Building '{}' ...", managedBuild.getId());
             managedBuild.delete(openShift);
             managedBuild.build(openShift);

--- a/core/src/main/java/cz/xtf/core/config/BuildManagerConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/BuildManagerConfig.java
@@ -3,6 +3,7 @@ package cz.xtf.core.config;
 public class BuildManagerConfig {
     public static final String BUILD_NAMESPACE = "xtf.bm.namespace";
     public static final String FORCE_REBUILD = "xtf.bm.force_rebuild";
+    public static final String SKIP_REBUILD = "xtf.bm.skip_rebuild";
     public static final String MAX_RUNNING_BUILDS = "xtf.bm.max_running_builds";
 
     public static String namespace() {
@@ -11,6 +12,10 @@ public class BuildManagerConfig {
 
     public static boolean forceRebuild() {
         return Boolean.valueOf(XTFConfig.get(FORCE_REBUILD, "false"));
+    }
+
+    public static boolean skipRebuild() {
+        return Boolean.valueOf(XTFConfig.get(SKIP_REBUILD, "false"));
     }
 
     public static int maxRunningBuilds() {


### PR DESCRIPTION
Please make sure your PR meets the following requirements:
- [ ] Pull Request contains a description of the changes
- [ ] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented

## Summary by Sourcery

Introduce a new SKIP_REBUILD configuration option and update BuildManager to bypass rebuilds when this flag is enabled.

New Features:
- Add SKIP_REBUILD property with a skipRebuild() accessor in BuildManagerConfig.
- Implement skip rebuild behavior in BuildManager when the skipRebuild flag is true.

Enhancements:
- Reorder rebuild logic to prioritize skipping over forcing and add log output for skipped builds.